### PR TITLE
Bugs - Golem joins wrong channel after leaving and returning

### DIFF
--- a/specs/player/music-player.spec.ts
+++ b/specs/player/music-player.spec.ts
@@ -214,6 +214,7 @@ describe('Music Player', () => {
         await musicPlayer.destroy()
 
         expect(MockGolem.removePlayer).toHaveBeenCalledWith(
+          MockJoinOptions.guildId,
           MockJoinOptions.channelId
         )
         expect(MockDiscordJS.VoiceConnection.destroy).toHaveBeenCalled()

--- a/src/aliases/custom-alias.ts
+++ b/src/aliases/custom-alias.ts
@@ -120,6 +120,8 @@ export class CustomAlias {
 
     if (CustomAlias.cache.has(guildId)) {
       CustomAlias.log.debug(`CustomAlias cache hit for ${guildId}`)
+      // Safe to non Null here
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       return CustomAlias.cache.get(guildId)!
     }
 

--- a/src/golem/player-cache.ts
+++ b/src/golem/player-cache.ts
@@ -52,6 +52,8 @@ export class PlayerCache {
         channelId: interaction.info.voiceChannel.id || '',
         guildId: interaction.info.guildId,
         adapterCreator: interaction.info.guild.voiceAdapterCreator,
+        guildName: interaction.info.guild.name,
+        channelName: interaction.info.voiceChannel.name,
       })
 
       this.data.set(interaction.info.guildId, player)

--- a/src/listing/album.ts
+++ b/src/listing/album.ts
@@ -34,6 +34,7 @@ export class LocalAlbum extends Album {
     })
 
     // TODO this is bad but also kind of hard to make happen so :shrug:
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return record!.art[size].buffer
   }
 

--- a/src/listing/listing-loaders.ts
+++ b/src/listing/listing-loaders.ts
@@ -148,9 +148,9 @@ export class ListingLoader {
       log.silly(`saved ${listing.names.short.dashed}`)
 
       return listing
-    } catch (error: any) {
+    } catch (error) {
       log.error(`${path} encountered error.`)
-      log.error(error.stack)
+      log.error((error as Error).stack)
       throw error
     }
   }

--- a/src/messages/custom-id.ts
+++ b/src/messages/custom-id.ts
@@ -21,6 +21,7 @@ export class CustomId<P extends InteractionIdPrefixes> {
   static fromString<T extends InteractionIdPrefixes>(
     idString: string
   ): CustomId<T> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const config: Record<string, any> = {
       args: {},
     }

--- a/src/player/music-player.ts
+++ b/src/player/music-player.ts
@@ -27,6 +27,12 @@ export type GolemTrackAudioResource = AudioResource & {
   metadata: TrackAudioResourceMetadata
 }
 
+export type MusicPlayerOptions = JoinVoiceChannelOptions &
+  CreateVoiceConnectionOptions & {
+    guildName: string
+    channelName: string
+  }
+
 export class MusicPlayer {
   static readonly autoDCTime = 300000
   private readonly queue!: TrackQueue
@@ -41,9 +47,7 @@ export class MusicPlayer {
 
   public readonly audioPlayer!: AudioPlayer
 
-  public constructor(
-    private options: JoinVoiceChannelOptions & CreateVoiceConnectionOptions
-  ) {
+  public constructor(private options: MusicPlayerOptions) {
     this.log = GolemLogger.child({ src: LogSources.MusicPlayer })
     this.queue = new TrackQueue()
     this.audioPlayer = createAudioPlayer()

--- a/src/player/music-player.ts
+++ b/src/player/music-player.ts
@@ -34,8 +34,9 @@ export type MusicPlayerOptions = JoinVoiceChannelOptions &
   }
 
 export class MusicPlayer {
-  static readonly autoDCTime = 300000
-  private readonly queue!: TrackQueue
+  static readonly autoDCTime = 20_000
+
+  private readonly queue: TrackQueue
   private readonly log: winston.Logger
 
   private leaveTimeout!: NodeJS.Timeout
@@ -45,10 +46,19 @@ export class MusicPlayer {
   public voiceConnection!: VoiceConnection
   public currentResource?: GolemTrackAudioResource
 
-  public readonly audioPlayer!: AudioPlayer
+  public readonly audioPlayer: AudioPlayer
+  public readonly guildName: string
+  public readonly channelName: string
+  public readonly channelId: string
 
   public constructor(private options: MusicPlayerOptions) {
-    this.log = GolemLogger.child({ src: LogSources.MusicPlayer })
+    this.log = GolemLogger.child({
+      src: LogSources.MusicPlayer,
+      aux: { guildName: options.guildName, channelName: options.channelName },
+    })
+    this.guildName = options.guildName
+    this.channelName = options.channelName
+    this.channelId = options.channelId
     this.queue = new TrackQueue()
     this.audioPlayer = createAudioPlayer()
 
@@ -57,6 +67,22 @@ export class MusicPlayer {
     this.audioPlayer.on('error', this.audioPlayErrorHandler.bind(this))
 
     this.joinVoice()
+  }
+
+  /**
+   * The primary key that the player should be referenced by.
+   * Currently the GuildID of the Player.
+   */
+  public get primaryKey(): string {
+    return this.options.guildId
+  }
+
+  /**
+   * The secondary key that the player should be referenced by.
+   * Currently the ChannlerId of the Player.
+   */
+  public get secondaryKey(): string {
+    return this.options.channelId
   }
 
   public get isPlaying(): boolean {
@@ -94,10 +120,6 @@ export class MusicPlayer {
 
   public get isDestroyed(): boolean {
     return this.voiceConnection.state.status === VoiceConnectionStatus.Destroyed
-  }
-
-  private get channelId(): string {
-    return this.options.channelId
   }
 
   public async enqueue(track: Track, enqueueAsNext = false): Promise<void> {
@@ -145,7 +167,7 @@ export class MusicPlayer {
 
   public async destroy(): Promise<void> {
     this.log.silly(
-      `attempt destroy voice connection for ${this.channelId} - state=${this.voiceConnection.state.status}`
+      `attempt destroy voice connection for ${this.primaryKey} - ${this.secondaryKey} - state=${this.voiceConnection.state.status}`
     )
     if (
       ![
@@ -153,11 +175,13 @@ export class MusicPlayer {
         VoiceConnectionStatus.Disconnected,
       ].includes(this.voiceConnection.state.status)
     ) {
-      this.log.debug(`destroying voice connection for ${this.channelId}`)
+      this.log.debug(
+        `destroying voice connection for ${this.primaryKey} - ${this.secondaryKey}`
+      )
 
       this.queueLock = false
       this.currentResource?.metadata.track.onSkip()
-      await Golem.removePlayer(this.channelId)
+      await Golem.removePlayer(this.primaryKey, this.secondaryKey)
       this.voiceConnection.destroy()
       Golem.setPresenceIdle()
     }
@@ -203,7 +227,9 @@ export class MusicPlayer {
         VoiceConnectionStatus.Disconnected,
       ].includes(this.voiceConnection.state.status)
     ) {
-      this.log.debug(`disconnecting voice connection for ${this.channelId}`)
+      this.log.debug(
+        `disconnecting voice connection for ${this.primaryKey} -  ${this.secondaryKey}`
+      )
 
       this.queueLock = false
       this.voiceConnection.disconnect()
@@ -238,7 +264,9 @@ export class MusicPlayer {
   }
 
   private startTimer(): void {
-    this.log.debug(`starting auto-dc timer for ${this.channelId}`)
+    this.log.debug(
+      `starting auto-dc timer for ${this.primaryKey} -  ${this.secondaryKey}`
+    )
     this.leaveTimeout = setTimeout(
       this.autoDisconnect.bind(this),
       MusicPlayer.autoDCTime
@@ -246,7 +274,9 @@ export class MusicPlayer {
   }
 
   private clearTimer(): void {
-    this.log.debug(`clearing auto-dc timer for ${this.channelId}`)
+    this.log.debug(
+      `clearing auto-dc timer for ${this.primaryKey} -  ${this.secondaryKey}`
+    )
     clearTimeout(this.leaveTimeout)
   }
 
@@ -258,7 +288,7 @@ export class MusicPlayer {
 
     if (this.isDestroyed) {
       this.log.debug(
-        `player destroyed at process attempt for ${this.channelId} - running rejoin and subscribe`
+        `player in destroyed state at process attempt for ${this.primaryKey}  -  ${this.secondaryKey} - running rejoin and subscribe`
       )
       this.joinVoice()
       // this.subscribe()
@@ -327,7 +357,7 @@ export class MusicPlayer {
     newState: AudioPlayerState
   ): Promise<void> {
     this.log.verbose(
-      `state change - player: ${this.channelId}; ${oldState.status} => ${newState.status}`
+      `state change - player: ${this.primaryKey} -  ${this.secondaryKey}; ${oldState.status} => ${newState.status}`
     )
 
     switch (newState.status) {

--- a/src/utils/image-utils.ts
+++ b/src/utils/image-utils.ts
@@ -4,6 +4,8 @@ import { GolemConf } from '../config'
 import { PlexLogo } from '../constants'
 
 export const ImageUtils = {
+  // Genuinely not sure about this any
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   averageColor: (img?: Buffer | string): any =>
     getAverageColor(img || PlexLogo, {
       algorithm: GolemConf.image.avgColorAlgorithm,

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk'
 import { v4 as uuidv4 } from 'uuid'
 import winston from 'winston'
+import { formatForLog } from './debug-utils'
 
 export enum LogLevel {
   Debug = 'debug',
@@ -11,7 +12,7 @@ export enum LogLevel {
 
 const { combine, timestamp, colorize, printf, json, splat } = winston.format
 
-const consoleLogFormat = printf(({ level, message, timestamp, src }) => {
+const consoleLogFormat = printf(({ level, message, timestamp, src, aux }) => {
   const d = new Date(timestamp)
   const hours = d.getHours().toString().padStart(2, '0')
   const minutes = d.getMinutes().toString().padStart(2, '0')
@@ -21,7 +22,9 @@ const consoleLogFormat = printf(({ level, message, timestamp, src }) => {
 
   const srcColor = LogSourceColors[src as LogSources] || chalk.white
 
-  return `${timeString} <${level}> [${srcColor(src)}] ${message}`
+  const auxLog = !!aux ? ` ${formatForLog(aux)}` : ''
+
+  return `${timeString} <${level}> [${srcColor(src)}] ${message}${auxLog}`
 })
 
 const id = winston.format((info) => {

--- a/test-utils/mocks/discordjs.ts
+++ b/test-utils/mocks/discordjs.ts
@@ -1,7 +1,4 @@
-import {
-  JoinVoiceChannelOptions,
-  CreateVoiceConnectionOptions,
-} from '@discordjs/voice'
+import { MusicPlayerOptions } from '../../src/player/music-player'
 import { MockedLocalListing, MockLocalListing } from './models/listing'
 import { MockLocalTrack } from './models/track'
 
@@ -55,9 +52,11 @@ export const MockVoiceConnection = {
 export const MockJoinOptions = {
   channelId: '828',
   guildId: 'clean',
+  guildName: 'sesang',
+  channelName: 'gugudan',
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   adapterCreator: () => {},
-} as unknown as JoinVoiceChannelOptions & CreateVoiceConnectionOptions
+} as unknown as MusicPlayerOptions
 
 enum AudioPlayerStatus {
   Idle = 'idle',


### PR DESCRIPTION
Fixes #28 

### Cause
Players were being cached via Voice Channel Id, and deleted via Guild ID. This meant no player was ever deleted - since nothing was saved by Guild ID.

### Solution
- update player cache to operate on a combo key of guildId and
  channelId
- also works using just guildId - for diag tools
- adds aux logging to append data for a log child instance
- add linting disables where needed