### PR TITLE
Bug - Youtube track time miscalculate

### DIFF
--- a/specs/commands/goskip.spec.ts
+++ b/specs/commands/goskip.spec.ts
@@ -51,7 +51,7 @@ describe('goskip', () => {
   it('should reply using the ListingEmbed if there is another track', async () => {
     await goskip.execute(mockMessage._toWrapper())
 
-    expect(MockedListingEmbed.send).toHaveBeenCalledWith('play', {
+    expect(MockedListingEmbed.send).toHaveBeenCalledWith('play', false, {
       content: 'Skipped!',
     })
   })

--- a/specs/player/music-player.spec.ts
+++ b/specs/player/music-player.spec.ts
@@ -89,11 +89,13 @@ describe('Music Player', () => {
         setCurrentResource()
         musicPlayer.currentResource!.playbackDuration = 100000
         MockedTrackQueue.runTime = 200
+        MockedTrackQueue.explicitQueueRunTime = 828
 
         expect(musicPlayer.stats).toEqual({
           count: 0,
           hTime: '04:40',
           time: 280,
+          explicitTime: 908,
         })
       })
     })

--- a/src/commands/implementations/goplaynext.ts
+++ b/src/commands/implementations/goplaynext.ts
@@ -5,7 +5,7 @@ import { Handlers } from '../../handlers'
 import { GolemMessage } from '../../messages/message-wrapper'
 import { GolemLogger, LogSources } from '../../utils/logger'
 
-const log = GolemLogger.child({ src: LogSources.GoPlay })
+const log = GolemLogger.child({ src: LogSources.GoPlayNext })
 
 const execute = async (interaction: GolemMessage): Promise<void> => {
   log.debug(`executing`)

--- a/src/commands/implementations/goskip.ts
+++ b/src/commands/implementations/goskip.ts
@@ -23,7 +23,7 @@ const execute = async (interaction: GolemMessage): Promise<void> => {
     if (interaction.player.currentResource) {
       const listingEmbed = new ListingEmbed(interaction)
 
-      await listingEmbed.send('play', { content: 'Skipped!' })
+      await listingEmbed.send('play', false, { content: 'Skipped!' })
     } else {
       await interaction.reply({
         content: 'Skipped! Queue empty.',

--- a/src/messages/replies/listing-embed.ts
+++ b/src/messages/replies/listing-embed.ts
@@ -28,9 +28,10 @@ export class ListingEmbed {
 
   async send(
     context: 'queue' | 'play',
+    isPlayNext?: boolean,
     content?: Partial<MessageOptions>
   ): Promise<void> {
-    const options = await this.messageOptions(context)
+    const options = await this.messageOptions(context, isPlayNext)
 
     await this.message.reply({
       ...content,
@@ -38,9 +39,14 @@ export class ListingEmbed {
     })
   }
 
-  async messageOptions(context: 'queue' | 'play'): Promise<MessageOptions> {
+  async messageOptions(
+    context: 'queue' | 'play',
+    isPlayNext?: boolean
+  ): Promise<MessageOptions> {
     const embed =
-      context === 'queue' ? await this.queueMessage() : await this.playMessage()
+      context === 'queue'
+        ? await this.queueMessage(isPlayNext)
+        : await this.playMessage()
 
     const options = {
       embeds: [embed],
@@ -54,14 +60,16 @@ export class ListingEmbed {
     return options
   }
 
-  private async queueMessage(): Promise<MessageEmbed> {
+  private async queueMessage(isPlayNext?: boolean): Promise<MessageEmbed> {
     const embed = await this.toMessage()
     const title = this.message.player?.isPlaying
       ? 'Added to Queue'
       : 'Now Playing'
     const description = this.message.player?.isPlaying
       ? `Starts In: ${humanReadableTime(
-          this.message.player?.stats.time - this.listing.duration
+          (!isPlayNext
+            ? this.message.player?.stats.time
+            : this.message.player?.stats.explicitTime) - this.listing.duration
         )}`
       : 'Starting Now'
 

--- a/src/player/music-player.ts
+++ b/src/player/music-player.ts
@@ -34,7 +34,7 @@ export type MusicPlayerOptions = JoinVoiceChannelOptions &
   }
 
 export class MusicPlayer {
-  static readonly autoDCTime = 20_000
+  static readonly autoDCTime = 300_000
 
   private readonly queue: TrackQueue
   private readonly log: winston.Logger
@@ -100,11 +100,18 @@ export class MusicPlayer {
     )
   }
 
-  public get stats(): { count: number; time: number; hTime: string } {
+  public get stats(): {
+    count: number
+    time: number
+    hTime: string
+    explicitTime: number
+  } {
     return {
       count: this.trackCount,
       time: this.queue.runTime + this.currentTrackRemaining,
       hTime: humanReadableTime(this.queue.runTime + this.currentTrackRemaining),
+      explicitTime:
+        this.queue.explicitQueueRunTime + this.currentTrackRemaining,
     }
   }
 
@@ -124,7 +131,7 @@ export class MusicPlayer {
 
   public async enqueue(track: Track, enqueueAsNext = false): Promise<void> {
     this.log.silly(`enqueue - VC Status = ${this.voiceConnection.state.status}`)
-    this.log.info(`queueing ${track.name}`)
+    this.log.info(`queueing${enqueueAsNext ? ' as next ' : ' '}${track.name}`)
 
     if (enqueueAsNext) {
       this.queue.addNext(track.userId, track)

--- a/src/player/play-handler.ts
+++ b/src/player/play-handler.ts
@@ -164,6 +164,7 @@ export class PlayHandler {
     playNext = false
   ): Promise<void> {
     const listingEmbed = new ListingEmbed(interaction, listing)
+    const type = interaction.player.isPlaying ? 'queue' : 'play'
 
     this.log.verbose('enqueing local track')
 
@@ -171,7 +172,7 @@ export class PlayHandler {
 
     await player.enqueue(track, playNext)
 
-    await listingEmbed.send('queue')
+    await listingEmbed.send(type, playNext)
   }
 
   isYoutubeQuery(query: string): boolean {
@@ -193,17 +194,13 @@ export class PlayHandler {
   ): Promise<void> {
     const track = await YoutubeTrack.fromUrl(interaction.info.userId, url)
     const listingEmbed = new ListingEmbed(interaction, track.listing)
+    const type = interaction.player.isPlaying ? 'queue' : 'play'
 
     this.log.verbose('enqueing youtube track')
 
     await player.enqueue(track, playNext)
 
-    // const { embed } = await GetEmbedFromListing(track.metadata, player, 'queue')
-
-    // await interaction.reply({
-    //   embeds: [embed],
-    // })
-    await listingEmbed.send('queue')
+    await listingEmbed.send(type, playNext)
   }
 
   /**

--- a/src/player/queue.ts
+++ b/src/player/queue.ts
@@ -119,6 +119,16 @@ export class TrackQueue {
     return estRunTime
   }
 
+  get explicitQueueRunTime(): number {
+    const estRunTime = this.explicitQueue.reduce((prev, curr) => {
+      return prev + curr.track.metadata.duration
+    }, 0)
+
+    log.silly(`Estimated Explicit Runtime ${estRunTime}`)
+
+    return estRunTime
+  }
+
   get queuedTrackCount(): number {
     return this.queue.length
   }

--- a/test-utils/mocks/queue.ts
+++ b/test-utils/mocks/queue.ts
@@ -1,6 +1,7 @@
 export const MockedTrackQueue = {
   queuedTrackCount: 0,
   runTime: 10,
+  explicitQueueRunTime: 2,
   addNext: jest.fn(),
   addMany: jest.fn(),
   add: jest.fn(),


### PR DESCRIPTION
Fixes  #7 

### Cause
The listing embed was not being told whether the action was a 'play' or 'queue' causing the time to be calculated as a negative. The time for the explicit PlayNext queue was not exposed for use in time-to-start calculations for playnext commands.

### Solution
- fix logic of getting "Up Next" or "starts in" for listing embed
- fix starts in time for playnext to show only time of tracks actually
  in front of the requested playnext track